### PR TITLE
FIX Add closing bracket to jq

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "Unable to fetch issues - HTTP response code was $RESP_CODE"
           exit 1
         fi
-        ISSUE_NUMBERS=$(jq -r --arg TITLE "$TITLE" '.[] | select(.title == $TITLE) | select(.user.login == "github-actions[bot]" | .number' __issues.json)
+        ISSUE_NUMBERS=$(jq -r --arg var1 "$TITLE" '.[] | select(.title == $var1) | select(.user.login == "github-actions[bot]") | .number' __issues.json)
         for ISSUE_NUMBER in $ISSUE_NUMBERS; do
           # https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue
           RESP_CODE=$(curl -w %{http_code} -s -o __issues.json \


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/243

Main thing was the closing bracket.  I also changed $TITLE to $var1, though it's not required it makes it clear that the jq $var1 isn't coming from the bash variable with the same name